### PR TITLE
Connect palette to canvas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,45 +3,66 @@
 import React from 'react';
 import './index.css';
 
-// Importiert unsere Komponenten und den State-Hook
 import Palette from './components/ComponentPalette/Palette';
 import CircuitCanvas from './components/Canvas/CircuitCanvas';
 import { useCircuitState } from './hooks/useCircuitState';
-import { ComponentType } from './types/circuit'; // Wir brauchen den ComponentType für unsere Beispieldaten
+import { CircuitComponent, ComponentType } from './types/circuit';
 
 export default function App() {
-  // Wir rufen unseren Hook auf, um den Zustand der Schaltung zu bekommen.
-  // Vorerst nutzen wir nur den 'state', die 'setState' Funktion kommt später.
   const { state, setState } = useCircuitState();
 
-  // Wir erstellen hier manuell ein paar Start-Komponenten zum Testen.
-  // Später werden diese aus der Palette hinzugefügt.
-  const initialComponents = {
-    'power-24v': {
-      id: 'power-24v',
-      type: ComponentType.PowerSource24V,
-      label: '+24V',
-      position: { x: 50, y: 50 },
-      pins: [], // Vorerst leer
-    },
-    'power-0v': {
-      id: 'power-0v',
-      type: ComponentType.PowerSource0V,
-      label: '0V',
-      position: { x: 50, y: 600 },
-      pins: [], // Vorerst leer
-    },
+  // Initialer Zustand mit den Stromschienen.
+  // Wird nur beim ersten Rendern verwendet.
+  React.useEffect(() => {
+    setState({
+      components: {
+        'power-24v': {
+          id: 'power-24v', type: ComponentType.PowerSource24V, label: '+24V',
+          position: { x: 50, y: 50 }, pins: [],
+        },
+        'power-0v': {
+          id: 'power-0v', type: ComponentType.PowerSource0V, label: '0V',
+          position: { x: 50, y: 600 }, pins: [],
+        },
+      },
+      connections: {},
+    });
+  }, [setState]); // Abhängigkeit von setState, um ESLint-Warnungen zu vermeiden
+
+
+  // Diese Funktion wird von der Palette aufgerufen, um ein neues Bauteil hinzuzufügen.
+  const handleAddComponent = (type: ComponentType) => {
+    // Erzeugt eine neue, einzigartige ID für das Bauteil
+    const newId = `${type.toLowerCase()}-${Date.now()}`;
+    
+    const newComponent: CircuitComponent = {
+      id: newId,
+      type: type,
+      label: newId, // Vorerst ein einfacher Label
+      position: { x: 150, y: 150 }, // Startposition für neue Bauteile
+      pins: [], // Pin-Logik kommt später
+    };
+
+    // Aktualisiert den Zustand: Behält alle alten Komponenten und fügt die neue hinzu.
+    setState(prevState => ({
+      ...prevState,
+      components: {
+        ...prevState.components,
+        [newId]: newComponent,
+      },
+    }));
   };
 
   return (
     <div className="app-container">
       <aside className="palette-container">
-        <Palette />
+        {/* Wir übergeben die handleAddComponent Funktion an die Palette */}
+        <Palette onAddComponent={handleAddComponent} />
       </aside>
 
       <main className="canvas-container">
-        {/* Wir übergeben unsere Test-Komponenten an die Zeichenfläche */}
-        <CircuitCanvas components={Object.values(initialComponents)} />
+        {/* Die Zeichenfläche erhält jetzt die Komponenten aus dem dynamischen Zustand */}
+        <CircuitCanvas components={Object.values(state.components)} />
       </main>
     </div>
   );

--- a/src/components/Canvas/CircuitCanvas.tsx
+++ b/src/components/Canvas/CircuitCanvas.tsx
@@ -3,62 +3,81 @@
 import React from 'react';
 import { CircuitComponent, ComponentType } from '../../types/circuit';
 
-// Definiert die 'Props' (Eigenschaften), die diese Komponente empfängt.
-// In diesem Fall ist es eine Liste von CircuitComponent-Objekten.
 interface CircuitCanvasProps {
   components: CircuitComponent[];
 }
 
-/**
- * Die Zeichenfläche, die eine Liste von Komponenten erhält und diese als SVG darstellt.
- */
 const CircuitCanvas: React.FC<CircuitCanvasProps> = ({ components }) => {
-  // Eine Hilfsfunktion, die entscheidet, WIE ein einzelnes Bauteil gezeichnet wird.
   const renderComponent = (component: CircuitComponent) => {
+    // Definieren wir ein paar Standard-SVG-Stile
+    const style = {
+      stroke: 'black',
+      strokeWidth: 2,
+      fill: 'none',
+    };
+
     switch (component.type) {
       case ComponentType.PowerSource24V:
       case ComponentType.PowerSource0V:
         return (
           <>
-            <line x1="0" y1="0" x2="400" y2="0" stroke="black" strokeWidth="2" />
-            <text x="-30" y="5" fontSize="12" fill="black">
+            <line x1="0" y1="0" x2="400" y2="0" {...style} />
+            <text x="-35" y="5" fontSize="14" fill="black">
               {component.label}
             </text>
           </>
         );
-      // Hier werden wir später weitere 'case' für andere Bauteile hinzufügen
-      // z.B. case ComponentType.NormallyOpen: ...
-      default:
-        // Falls ein unbekannter Typ kommt, zeichnen wir einen Platzhalter
+
+      case ComponentType.NormallyOpen: // Schließer
         return (
-          <rect
-            width="40"
-            height="20"
-            fill="lightgrey"
-            stroke="red"
-            strokeDasharray="5,5"
-          />
+          <>
+            <line x1="10" y1="0" x2="10" y2="10" {...style} />
+            <line x1="10" y1="30" x2="10" y2="40" {...style} />
+            <line x1="0" y1="10" x2="10" y2="20" {...style} />
+            <text x="20" y="25" fontSize="12">{component.label}</text>
+          </>
+        );
+
+      case ComponentType.NormallyClosed: // Öffner
+        return (
+          <>
+            <line x1="10" y1="0" x2="10" y2="15" {...style} />
+            <line x1="10" y1="25" x2="10" y2="40" {...style} />
+            <line x1="10" y1="15" x2="20" y2="25" {...style} />
+            <text x="25" y="25" fontSize="12">{component.label}</text>
+          </>
+        );
+
+      case ComponentType.Motor:
+        return (
+          <>
+            <circle cx="20" cy="20" r="18" {...style} fill="white" />
+            <text x="16" y="25" fontSize="18" fontWeight="bold" fill="black">M</text>
+            <text x="45" y="25" fontSize="12">{component.label}</text>
+          </>
+        );
+
+      case ComponentType.Lamp:
+         return (
+          <>
+            <circle cx="20" cy="20" r="18" {...style} fill="white" />
+            <line x1="5" y1="5" x2="35" y2="35" {...style} />
+            <line x1="35" y1="5" x2="5" y2="35" {...style} />
+            <text x="45" y="25" fontSize="12">{component.label}</text>
+          </>
+        );
+
+      default:
+        return (
+          <rect width="40" height="20" fill="lightgrey" stroke="red" />
         );
     }
   };
 
   return (
-    // Das SVG-Element ist unsere Leinwand.
-    <svg
-      width="100%"
-      height="100%"
-      style={{ backgroundColor: 'white', border: '1px solid #ccc' }}
-    >
-      {/* Wir gehen durch die Liste der Komponenten.
-        Für jede Komponente erstellen wir eine SVG-Gruppe ('g').
-        Diese Gruppe verschieben wir an die Position der Komponente.
-      */}
+    <svg width="100%" height="100%" style={{ backgroundColor: 'white', border: '1px solid #ccc' }}>
       {components.map((component) => (
-        <g
-          key={component.id}
-          transform={`translate(${component.position.x}, ${component.position.y})`}
-        >
-          {/* Wir rufen unsere Hilfsfunktion auf, um die eigentliche Grafik zu malen */}
+        <g key={component.id} transform={`translate(${component.position.x}, ${component.position.y})`}>
           {renderComponent(component)}
         </g>
       ))}

--- a/src/components/ComponentPalette/Palette.tsx
+++ b/src/components/ComponentPalette/Palette.tsx
@@ -1,10 +1,35 @@
 import React from 'react';
+import { ComponentType } from '../../types/circuit';
+import Button from '../UI/Button'; // Wir verwenden unsere Button-Komponente
 
-/**
- * Platzhalter für die Palette der elektrischen Komponenten.
- */
-const Palette: React.FC = () => {
-  return <div>Palette</div>;
+interface PaletteProps {
+  onAddComponent: (type: ComponentType) => void;
+}
+
+const Palette: React.FC<PaletteProps> = ({ onAddComponent }) => {
+  return (
+    <div>
+      <h3 style={{ marginTop: 0 }}>Bauteile</h3>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+        <Button
+          label="Schließer hinzufügen"
+          onClick={() => onAddComponent(ComponentType.NormallyOpen)}
+        />
+        <Button
+          label="Öffner hinzufügen"
+          onClick={() => onAddComponent(ComponentType.NormallyClosed)}
+        />
+        <Button
+          label="Motor hinzufügen"
+          onClick={() => onAddComponent(ComponentType.Motor)}
+        />
+        <Button
+          label="Lampe hinzufügen"
+          onClick={() => onAddComponent(ComponentType.Lamp)}
+        />
+      </div>
+    </div>
+  );
 };
 
 export default Palette;


### PR DESCRIPTION
## Summary
- hook up component palette buttons to add components
- render new component types on the canvas
- maintain dynamic circuit state and allow adding components from palette

## Testing
- `yarn test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6845fd13e5fc8327916b92809e5e37b7