### PR TITLE
Add details sidebar and component selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,41 +1,99 @@
 import React from 'react';
 import './index.css';
-
 import Palette from './components/ComponentPalette/Palette';
 import CircuitCanvas from './components/Canvas/CircuitCanvas';
+import DetailsSidebar from './components/UI/DetailsSidebar';
 import { useCircuitState } from './hooks/useCircuitState';
 import { CircuitComponent, ComponentType, Pin } from './types/circuit';
 
-interface DraggingInfo { componentId: string; offsetX: number; offsetY: number; }
-interface ConnectingInfo { startPinId: string | null; }
+interface DraggingInfo {
+  componentId: string;
+  offsetX: number;
+  offsetY: number;
+}
+
+interface ConnectingInfo {
+  startPinId: string | null;
+}
 
 export default function App() {
   const { state, setState } = useCircuitState();
   const [draggingInfo, setDraggingInfo] = React.useState<DraggingInfo | null>(null);
   const [connectingInfo, setConnectingInfo] = React.useState<ConnectingInfo>({ startPinId: null });
   const [mousePosition, setMousePosition] = React.useState({ x: 0, y: 0 });
-
-  // KORREKTUR: Wir brauchen eine Referenz auf unser SVG-Element
+  const [selectedComponentId, setSelectedComponentId] = React.useState<string | null>(null);
   const svgRef = React.useRef<SVGSVGElement>(null);
 
-  // Der Rest der Funktionen (useEffect, createPinsForComponent, handleAddComponent) bleibt unverändert...
-  React.useEffect(() => { setState({ components: { 'power-24v': { id: 'power-24v', type: ComponentType.PowerSource24V, label: '+24V', position: { x: 50, y: 50 }, pins: [] }, 'power-0v': { id: 'power-0v', type: ComponentType.PowerSource0V, label: '0V', position: { x: 50, y: 600 }, pins: [] }, }, connections: {}, }); }, [setState]);
-  const createPinsForComponent = (componentId: string, type: ComponentType): Pin[] => { switch (type) { case ComponentType.NormallyOpen: case ComponentType.NormallyClosed: return [ { id: `${componentId}-p1`, componentId, label: '1', position: { x: 10, y: 0 } }, { id: `${componentId}-p2`, componentId, label: '2', position: { x: 10, y: 40 } }, ]; case ComponentType.Motor: case ComponentType.Lamp: return [ { id: `${componentId}-p1`, componentId, label: 'A1', position: { x: 20, y: 2 } }, { id: `${componentId}-p2`, componentId, label: 'A2', position: { x: 20, y: 38 } }, ]; default: return []; } };
-  const handleAddComponent = (type: ComponentType) => { const newId = `${type.toLowerCase()}-${Date.now()}`; const pins = createPinsForComponent(newId, type); const newComponent: CircuitComponent = { id: newId, type, label: newId, position: { x: 150, y: 150 }, pins, }; setState(prevState => ({ ...prevState, components: { ...prevState.components, [newId]: newComponent }, })); };
+  React.useEffect(() => {
+    setState({
+      components: {
+        'power-24v': {
+          id: 'power-24v',
+          type: ComponentType.PowerSource24V,
+          label: '+24V',
+          position: { x: 50, y: 50 },
+          pins: [],
+        },
+        'power-0v': {
+          id: 'power-0v',
+          type: ComponentType.PowerSource0V,
+          label: '0V',
+          position: { x: 50, y: 600 },
+          pins: [],
+        },
+      },
+      connections: {},
+    });
+  }, [setState]);
 
+  const createPinsForComponent = (componentId: string, type: ComponentType): Pin[] => {
+    switch (type) {
+      case ComponentType.NormallyOpen:
+      case ComponentType.NormallyClosed:
+        return [
+          { id: `${componentId}-p1`, componentId, label: '1', position: { x: 10, y: 0 } },
+          { id: `${componentId}-p2`, componentId, label: '2', position: { x: 10, y: 40 } },
+        ];
+      case ComponentType.Motor:
+      case ComponentType.Lamp:
+        return [
+          { id: `${componentId}-p1`, componentId, label: 'A1', position: { x: 20, y: 2 } },
+          { id: `${componentId}-p2`, componentId, label: 'A2', position: { x: 20, y: 38 } },
+        ];
+      default:
+        return [];
+    }
+  };
 
-  const getCoordsInSvg = (e: React.MouseEvent): {x: number, y: number} => {
+  const handleAddComponent = (type: ComponentType) => {
+    const newId = `${type.toLowerCase()}-${Date.now()}`;
+    const pins = createPinsForComponent(newId, type);
+    const newComponent: CircuitComponent = {
+      id: newId,
+      type,
+      label: newId,
+      position: { x: 150, y: 150 },
+      pins,
+    };
+    setState(prevState => ({
+      ...prevState,
+      components: { ...prevState.components, [newId]: newComponent },
+    }));
+  };
+
+  const getCoordsInSvg = (e: React.MouseEvent): { x: number; y: number } => {
     const svg = svgRef.current;
-    if (!svg) return { x: 0, y: 0};
+    if (!svg) return { x: 0, y: 0 };
     const pt = svg.createSVGPoint();
     pt.x = e.clientX;
     pt.y = e.clientY;
     const svgP = pt.matrixTransform(svg.getScreenCTM()?.inverse());
     return { x: svgP.x, y: svgP.y };
-  }
+  };
 
   const handleMouseDownOnComponent = (e: React.MouseEvent, componentId: string) => {
     e.preventDefault();
+    setSelectedComponentId(componentId);
     const component = state.components[componentId];
     if (!component) return;
     const mouseCoords = getCoordsInSvg(e);
@@ -52,31 +110,82 @@ export default function App() {
       const { componentId, offsetX, offsetY } = draggingInfo;
       const newX = currentMousePos.x - offsetX;
       const newY = currentMousePos.y - offsetY;
-      setState(prevState => ({ ...prevState, components: { ...prevState.components, [componentId]: { ...prevState.components[componentId], position: { x: newX, y: newY }, }, }, }));
+      setState(prevState => ({
+        ...prevState,
+        components: {
+          ...prevState.components,
+          [componentId]: {
+            ...prevState.components[componentId],
+            position: { x: newX, y: newY },
+          },
+        },
+      }));
     }
   };
 
-  const handleMouseUp = () => { setDraggingInfo(null); };
+  const handleMouseUp = () => {
+    setDraggingInfo(null);
+  };
 
-  const handleCanvasClick = () => { if (connectingInfo.startPinId) { setConnectingInfo({ startPinId: null }); } };
+  const handleCanvasClick = () => {
+    if (connectingInfo.startPinId) {
+      setConnectingInfo({ startPinId: null });
+    }
+  };
 
   const handlePinClick = (e: React.MouseEvent, pinId: string) => {
     e.stopPropagation();
+    setSelectedComponentId(null);
     if (!connectingInfo.startPinId) {
       setConnectingInfo({ startPinId: pinId });
     } else {
-        if(connectingInfo.startPinId === pinId) return; // Verhindert Verbindung mit sich selbst
-        const newConnectionId = `conn-${connectingInfo.startPinId}-${pinId}`;
-        setState(prevState => ({ ...prevState, connections: { ...prevState.connections, [newConnectionId]: { id: newConnectionId, startPinId: connectingInfo.startPinId!, endPinId: pinId } } }));
-        setConnectingInfo({ startPinId: null });
+      if (connectingInfo.startPinId === pinId) return;
+      const newConnectionId = `conn-${connectingInfo.startPinId}-${pinId}`;
+      setState(prevState => ({
+        ...prevState,
+        connections: {
+          ...prevState.connections,
+          [newConnectionId]: {
+            id: newConnectionId,
+            startPinId: connectingInfo.startPinId!,
+            endPinId: pinId,
+          },
+        },
+      }));
+      setConnectingInfo({ startPinId: null });
     }
   };
 
   const getConnectingInfoForCanvas = () => {
     if (!connectingInfo.startPinId) return null;
-    const startPin = Object.values(state.components).flatMap(c => c.pins).find(p => p.id === connectingInfo.startPinId);
+    const startPin = Object.values(state.components)
+      .flatMap(c => c.pins)
+      .find(p => p.id === connectingInfo.startPinId);
     if (!startPin) return null;
     return { startPin, mousePosition };
+  };
+
+  const handleDeleteComponent = (componentId: string) => {
+    setState(prevState => {
+      const newComponents = { ...prevState.components };
+      delete newComponents[componentId];
+
+      const newConnections = { ...prevState.connections };
+      Object.values(newConnections).forEach(conn => {
+        const startComp = prevState.components[
+          prevState.connections[conn.id].startPinId.split('-p')[0]
+        ];
+        const endComp = prevState.components[
+          prevState.connections[conn.id].endPinId.split('-p')[0]
+        ];
+        if (startComp?.id === componentId || endComp?.id === componentId) {
+          delete newConnections[conn.id];
+        }
+      });
+
+      return { components: newComponents, connections: newConnections };
+    });
+    setSelectedComponentId(null);
   };
 
   return (
@@ -86,9 +195,10 @@ export default function App() {
       </aside>
       <main className="canvas-container">
         <CircuitCanvas
-          svgRef={svgRef} // Wir übergeben die Ref an die Canvas
+          svgRef={svgRef}
           components={state.components}
           connections={state.connections}
+          selectedComponentId={selectedComponentId}
           onComponentMouseDown={handleMouseDownOnComponent}
           onPinClick={handlePinClick}
           onMouseMove={handleMouseMove}
@@ -97,6 +207,11 @@ export default function App() {
           connectingInfo={getConnectingInfoForCanvas()}
         />
       </main>
+      <DetailsSidebar
+        selectedComponent={selectedComponentId ? state.components[selectedComponentId] : null}
+        onDelete={handleDeleteComponent}
+        onClose={() => setSelectedComponentId(null)}
+      />
     </div>
   );
 }

--- a/src/components/Canvas/CircuitCanvas.tsx
+++ b/src/components/Canvas/CircuitCanvas.tsx
@@ -3,38 +3,84 @@ import { CircuitComponent, Connection, Pin } from '../../types/circuit';
 import DraggableComponent from '../ElectricalComponents/DraggableComponent';
 
 interface CircuitCanvasProps {
-  svgRef: React.RefObject<SVGSVGElement>; // Neue Prop für die Ref
-  // ... restliche Props bleiben gleich
+  svgRef: React.RefObject<SVGSVGElement>;
   components: { [id: string]: CircuitComponent };
   connections: { [id: string]: Connection };
+  selectedComponentId: string | null;
   onComponentMouseDown: (e: React.MouseEvent, componentId: string) => void;
   onPinClick: (e: React.MouseEvent, pinId: string) => void;
   onMouseMove: (e: React.MouseEvent) => void;
   onMouseUp: () => void;
   onCanvasClick: () => void;
-  connectingInfo?: { startPin: Pin; mousePosition: { x: number, y: number } } | null;
+  connectingInfo?: { startPin: Pin; mousePosition: { x: number; y: number } } | null;
 }
 
 const CircuitCanvas: React.FC<CircuitCanvasProps> = (props) => {
-    const { svgRef, components, connections, onComponentMouseDown, onPinClick, onMouseMove, onMouseUp, onCanvasClick, connectingInfo } = props;
+  const {
+    svgRef,
+    components,
+    connections,
+    selectedComponentId,
+    onComponentMouseDown,
+    onPinClick,
+    onMouseMove,
+    onMouseUp,
+    onCanvasClick,
+    connectingInfo,
+  } = props;
 
-    // ... getAbsolutePinPosition bleibt unverändert ...
-    const getAbsolutePinPosition = (pinId: string) => { const pin = Object.values(components).flatMap(c => c.pins).find(p => p.id === pinId); if (!pin) return { x: 0, y: 0 }; const component = components[pin.componentId]; return { x: component.position.x + pin.position.x, y: component.position.y + pin.position.y, }; };
+  const getAbsolutePinPosition = (pinId: string) => {
+    const pin = Object.values(components)
+      .flatMap(c => c.pins)
+      .find(p => p.id === pinId);
+    if (!pin) return { x: 0, y: 0 };
+    const component = components[pin.componentId];
+    return {
+      x: component.position.x + pin.position.x,
+      y: component.position.y + pin.position.y,
+    };
+  };
 
-    return (
-        <svg
-            ref={svgRef} // Binde die Ref hier
-            width="100%" height="100%"
-            style={{ backgroundColor: 'white', border: '1px solid #ccc' }}
-            onMouseMove={onMouseMove} onMouseUp={onMouseUp} onMouseLeave={onMouseUp}
-            onClick={onCanvasClick}
-        >
-            {/* Restlicher Inhalt bleibt unverändert */}
-            {Object.values(connections).map(conn => { const start = getAbsolutePinPosition(conn.startPinId); const end = getAbsolutePinPosition(conn.endPinId); return <line key={conn.id} x1={start.x} y1={start.y} x2={end.x} y2={end.y} stroke="black" strokeWidth="2" />; })}
-            {connectingInfo && ( <line x1={getAbsolutePinPosition(connectingInfo.startPin.id).x} y1={getAbsolutePinPosition(connectingInfo.startPin.id).y} x2={connectingInfo.mousePosition.x} y2={connectingInfo.mousePosition.y} stroke="red" strokeWidth="2" strokeDasharray="5,5" /> )}
-            {Object.values(components).map((component) => ( <DraggableComponent key={component.id} component={component} onMouseDown={onComponentMouseDown} onPinClick={onPinClick} /> ))}
-        </svg>
-    );
+  return (
+    <svg
+      ref={svgRef}
+      width="100%"
+      height="100%"
+      style={{ backgroundColor: 'white', border: '1px solid #ccc' }}
+      onMouseMove={onMouseMove}
+      onMouseUp={onMouseUp}
+      onMouseLeave={onMouseUp}
+      onClick={onCanvasClick}
+    >
+      {Object.values(connections).map(conn => {
+        const start = getAbsolutePinPosition(conn.startPinId);
+        const end = getAbsolutePinPosition(conn.endPinId);
+        return (
+          <line key={conn.id} x1={start.x} y1={start.y} x2={end.x} y2={end.y} stroke="black" strokeWidth={2} />
+        );
+      })}
+      {connectingInfo && (
+        <line
+          x1={getAbsolutePinPosition(connectingInfo.startPin.id).x}
+          y1={getAbsolutePinPosition(connectingInfo.startPin.id).y}
+          x2={connectingInfo.mousePosition.x}
+          y2={connectingInfo.mousePosition.y}
+          stroke="red"
+          strokeWidth={2}
+          strokeDasharray="5,5"
+        />
+      )}
+      {Object.values(components).map(component => (
+        <DraggableComponent
+          key={component.id}
+          component={component}
+          isSelected={component.id === selectedComponentId}
+          onMouseDown={onComponentMouseDown}
+          onPinClick={onPinClick}
+        />
+      ))}
+    </svg>
+  );
 };
 
 export default CircuitCanvas;

--- a/src/components/ElectricalComponents/DraggableComponent.tsx
+++ b/src/components/ElectricalComponents/DraggableComponent.tsx
@@ -3,14 +3,17 @@ import { CircuitComponent, ComponentType } from '../../types/circuit';
 
 interface DraggableComponentProps {
   component: CircuitComponent;
+  isSelected: boolean; // NEU
   onMouseDown: (e: React.MouseEvent, componentId: string) => void;
   onPinClick: (e: React.MouseEvent, pinId: string) => void;
 }
 
-const DraggableComponent: React.FC<DraggableComponentProps> = ({ component, onMouseDown, onPinClick }) => {
+const DraggableComponent: React.FC<DraggableComponentProps> = ({ component, isSelected, onMouseDown, onPinClick }) => {
   const renderVisual = () => {
-    const style: React.CSSProperties = { stroke: 'black', strokeWidth: 2, fill: 'none', cursor: 'grab' };
-    const textStyle: React.CSSProperties = { fontSize: '12px', userSelect: 'none' };
+    // NEU: Der Stil ändert sich, wenn das Bauteil ausgewählt ist
+    const strokeColor = isSelected ? '#007bff' : 'black';
+    const style: React.CSSProperties = { stroke: strokeColor, strokeWidth: 2, fill: 'none', cursor: 'grab' };
+    const textStyle: React.CSSProperties = { fontSize: '12px', userSelect: 'none', fill: strokeColor };
 
     switch (component.type) {
       case ComponentType.PowerSource24V:

--- a/src/components/UI/DetailsSidebar.tsx
+++ b/src/components/UI/DetailsSidebar.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { CircuitComponent } from '../../types/circuit';
+
+interface DetailsSidebarProps {
+  selectedComponent: CircuitComponent | null;
+  onDelete: (componentId: string) => void;
+  onClose: () => void;
+}
+
+const DetailsSidebar: React.FC<DetailsSidebarProps> = ({ selectedComponent, onDelete, onClose }) => {
+  if (!selectedComponent) {
+    return null; // Don't render anything if no component is selected
+  }
+
+  return (
+    <aside className="details-sidebar">
+      <div className="sidebar-header">
+        <h3>Bauteil Details</h3>
+        <button onClick={onClose} className="close-btn">&times;</button>
+      </div>
+      <div className="sidebar-content">
+        <p><strong>ID:</strong> {selectedComponent.id}</p>
+        <p><strong>Typ:</strong> {selectedComponent.type}</p>
+        <p><strong>Bezeichnung:</strong></p>
+        <input
+          type="text"
+          value={selectedComponent.label}
+          // Note: Editing functionality will be added in the next step
+          readOnly
+          className="details-input"
+        />
+        <button onClick={() => onDelete(selectedComponent.id)} className="delete-btn">
+          Bauteil löschen
+        </button>
+      </div>
+    </aside>
+  );
+};
+
+export default DetailsSidebar;

--- a/src/index.css
+++ b/src/index.css
@@ -40,3 +40,59 @@ body {
   align-items: center;
 }
 
+
+/* src/index.css - HINZUFÜGEN */
+
+.details-sidebar {
+  width: 250px;
+  padding: 1rem;
+  background-color: #ffffff;
+  border-left: 1px solid #d9d9d9;
+  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.sidebar-header h3 {
+  margin: 0;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.details-input {
+  width: 100%;
+  padding: 8px;
+  margin-top: 4px;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.delete-btn {
+  width: 100%;
+  padding: 10px;
+  background-color: #f44336; /* Red */
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: auto; /* Pushes the button to the bottom */
+}
+
+.delete-btn:hover {
+  background-color: #d32f2f;
+}


### PR DESCRIPTION
## Summary
- add sidebar component to show component details and delete selected item
- style sidebar in `index.css`
- highlight selected component in `DraggableComponent`
- track selected component in `App` and allow deletion
- pass selection info through `CircuitCanvas`

## Testing
- `yarn test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684617fc6524832787a412631cd7d6f0