### PR TITLE
Add play/stop simulation mode with component state

### DIFF
--- a/src/components/Canvas/CircuitCanvas.tsx
+++ b/src/components/Canvas/CircuitCanvas.tsx
@@ -9,6 +9,7 @@ interface CircuitCanvasProps {
   selectedComponentId: string | null;
   onComponentMouseDown: (e: React.MouseEvent, componentId: string) => void;
   onPinClick: (e: React.MouseEvent, pinId: string) => void;
+  onComponentClick: (e: React.MouseEvent, componentId: string) => void; // NEU
   onMouseMove: (e: React.MouseEvent) => void;
   onMouseUp: () => void;
   onCanvasClick: () => void;
@@ -23,6 +24,7 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = (props) => {
     selectedComponentId,
     onComponentMouseDown,
     onPinClick,
+    onComponentClick,
     onMouseMove,
     onMouseUp,
     onCanvasClick,
@@ -77,6 +79,7 @@ const CircuitCanvas: React.FC<CircuitCanvasProps> = (props) => {
           isSelected={component.id === selectedComponentId}
           onMouseDown={onComponentMouseDown}
           onPinClick={onPinClick}
+          onComponentClick={onComponentClick}
         />
       ))}
     </svg>

--- a/src/components/ComponentPalette/Palette.tsx
+++ b/src/components/ComponentPalette/Palette.tsx
@@ -1,31 +1,36 @@
+// src/components/ComponentPalette/Palette.tsx
+
 import React from 'react';
 import { ComponentType } from '../../types/circuit';
-import Button from '../UI/Button'; // Wir verwenden unsere Button-Komponente
+import Button from '../UI/Button';
 
 interface PaletteProps {
   onAddComponent: (type: ComponentType) => void;
+  onToggleSimulation: () => void; // NEU
+  isSimulating: boolean; // NEU
 }
 
-const Palette: React.FC<PaletteProps> = ({ onAddComponent }) => {
+const Palette: React.FC<PaletteProps> = ({ onAddComponent, onToggleSimulation, isSimulating }) => {
   return (
-    <div>
-      <h3 style={{ marginTop: 0 }}>Bauteile</h3>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div>
+        <h3 style={{ marginTop: 0 }}>Bauteile</h3>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          {/* Die Buttons sind im Simulationsmodus deaktiviert */}
+          <Button label="Schließer hinzufügen" onClick={() => onAddComponent(ComponentType.NormallyOpen)} disabled={isSimulating} />
+          <Button label="Öffner hinzufügen" onClick={() => onAddComponent(ComponentType.NormallyClosed)} disabled={isSimulating} />
+          <Button label="Motor hinzufügen" onClick={() => onAddComponent(ComponentType.Motor)} disabled={isSimulating} />
+          <Button label="Lampe hinzufügen" onClick={() => onAddComponent(ComponentType.Lamp)} disabled={isSimulating} />
+        </div>
+      </div>
+
+      {/* NEU: Simulations-Steuerung am unteren Rand der Palette */}
+      <div style={{ marginTop: 'auto' }}>
+        <h3 style={{ borderTop: '1px solid #ccc', paddingTop: '1rem' }}>Simulation</h3>
         <Button
-          label="Schließer hinzufügen"
-          onClick={() => onAddComponent(ComponentType.NormallyOpen)}
-        />
-        <Button
-          label="Öffner hinzufügen"
-          onClick={() => onAddComponent(ComponentType.NormallyClosed)}
-        />
-        <Button
-          label="Motor hinzufügen"
-          onClick={() => onAddComponent(ComponentType.Motor)}
-        />
-        <Button
-          label="Lampe hinzufügen"
-          onClick={() => onAddComponent(ComponentType.Lamp)}
+          label={isSimulating ? 'Simulation Stoppen' : 'Simulation Starten'}
+          onClick={onToggleSimulation}
+          style={{ backgroundColor: isSimulating ? '#f44336' : '#4CAF50', color: 'white', width: '100%' }}
         />
       </div>
     </div>

--- a/src/components/ElectricalComponents/DraggableComponent.tsx
+++ b/src/components/ElectricalComponents/DraggableComponent.tsx
@@ -1,16 +1,18 @@
+// src/components/ElectricalComponents/DraggableComponent.tsx
+
 import React from 'react';
 import { CircuitComponent, ComponentType } from '../../types/circuit';
 
 interface DraggableComponentProps {
   component: CircuitComponent;
-  isSelected: boolean; // NEU
+  isSelected: boolean;
   onMouseDown: (e: React.MouseEvent, componentId: string) => void;
   onPinClick: (e: React.MouseEvent, pinId: string) => void;
+  onComponentClick: (e: React.MouseEvent, componentId: string) => void; // NEU
 }
 
-const DraggableComponent: React.FC<DraggableComponentProps> = ({ component, isSelected, onMouseDown, onPinClick }) => {
+const DraggableComponent: React.FC<DraggableComponentProps> = ({ component, isSelected, onMouseDown, onPinClick, onComponentClick }) => {
   const renderVisual = () => {
-    // NEU: Der Stil ändert sich, wenn das Bauteil ausgewählt ist
     const strokeColor = isSelected ? '#007bff' : 'black';
     const style: React.CSSProperties = { stroke: strokeColor, strokeWidth: 2, fill: 'none', cursor: 'grab' };
     const textStyle: React.CSSProperties = { fontSize: '12px', userSelect: 'none', fill: strokeColor };
@@ -26,31 +28,72 @@ const DraggableComponent: React.FC<DraggableComponentProps> = ({ component, isSe
             </text>
           </>
         );
-      case ComponentType.NormallyOpen:
+
+      case ComponentType.NormallyOpen: // Schließer
+        // NEU: Zeichnet basierend auf dem Zustand
+        if (component.state?.isOpen === false) {
+          // Geschlossen
+          return (
+            <>
+              <line x1="10" y1="0" x2="10" y2="40" style={style} />
+              <text x="20" y="25" style={textStyle}>{component.label}</text>
+            </>
+          );
+        }
+        // Offen (Standard)
         return (
           <>
-            <line x1="10" y1="0" x2="10" y2="10" style={style} /><line x1="10" y1="30" x2="10" y2="40" style={style} /><line x1="0" y1="10" x2="10" y2="20" style={style} /><text x="20" y="25" style={textStyle}>{component.label}</text>
+            <line x1="10" y1="0" x2="10" y2="10" style={style} />
+            <line x1="10" y1="30" x2="10" y2="40" style={style} />
+            <line x1="0" y1="10" x2="10" y2="20" style={style} />
+            <text x="20" y="25" style={textStyle}>{component.label}</text>
           </>
         );
-      case ComponentType.NormallyClosed:
+
+      case ComponentType.NormallyClosed: // Öffner
+        // NEU: Zeichnet basierend auf dem Zustand
+        if (component.state?.isOpen === true) {
+          // Geöffnet
+          return (
+            <>
+              <line x1="10" y1="0" x2="10" y2="10" style={style} />
+              <line x1="10" y1="30" x2="10" y2="40" style={style} />
+              <line x1="0" y1="10" x2="10" y2="20" style={style} />
+              <text x="25" y="25" style={textStyle}>{component.label}</text>
+            </>
+          );
+        }
+        // Geschlossen (Standard)
         return (
           <>
-            <line x1="10" y1="0" x2="10" y2="15" style={style} /><line x1="10" y1="25" x2="10" y2="40" style={style} /><line x1="10" y1="15" x2="20" y2="25" style={style} /><text x="25" y="25" style={textStyle}>{component.label}</text>
+            <line x1="10" y1="0" x2="10" y2="15" style={style} />
+            <line x1="10" y1="25" x2="10" y2="40" style={style} />
+            <line x1="10" y1="15" x2="20" y2="25" style={style} />
+            <text x="25" y="25" style={textStyle}>{component.label}</text>
           </>
         );
+
       case ComponentType.Motor:
         return (
           <>
-            <circle cx="20" cy="20" r="18" style={style} fill="white" /><text x="16" y="25" fontSize="18" fontWeight="bold" fill="black" style={textStyle}>M</text><text x="45" y="25" style={textStyle}>{component.label}</text>
+            <circle cx="20" cy="20" r="18" style={style} fill="white" />
+            <text x="16" y="25" fontSize="18" fontWeight="bold" fill="black" style={textStyle}>M</text>
+            <text x="45" y="25" style={textStyle}>{component.label}</text>
           </>
         );
+
       case ComponentType.Lamp:
         return (
           <>
-            <circle cx="20" cy="20" r="18" style={style} fill="white" /><line x1="5" y1="5" x2="35" y2="35" style={style} /><line x1="35" y1="5" x2="5" y2="35" style={style} /><text x="45" y="25" style={textStyle}>{component.label}</text>
+            <circle cx="20" cy="20" r="18" style={style} fill="white" />
+            <line x1="5" y1="5" x2="35" y2="35" style={style} />
+            <line x1="35" y1="5" x2="5" y2="35" style={style} />
+            <text x="45" y="25" style={textStyle}>{component.label}</text>
           </>
         );
+
       default:
+        // Die restlichen Bauteile bleiben wie sie sind
         return <rect width="40" height="20" fill="lightgrey" stroke="red" style={style} />;
     }
   };
@@ -59,6 +102,7 @@ const DraggableComponent: React.FC<DraggableComponentProps> = ({ component, isSe
     <g
       transform={`translate(${component.position.x}, ${component.position.y})`}
       onMouseDown={(e) => onMouseDown(e, component.id)}
+      onClick={(e) => onComponentClick(e, component.id)} // NEU: Klick auf das ganze Bauteil
     >
       {renderVisual()}
       {component.pins.map(pin => (

--- a/src/types/circuit.ts
+++ b/src/types/circuit.ts
@@ -33,6 +33,7 @@ export interface CircuitComponent {
   label: string;                // Die vom Benutzer vergebene Bezeichnung, z.B. 'S1'
   position: { x: number; y: number }; // Die X/Y-Koordinaten auf der Zeichenfläche
   pins: Pin[];                  // Eine Liste der Anschlusspunkte
+  state?: { [key: string]: any }; // NEU: Optionaler Zustand für das Bauteil
 }
 
 /**


### PR DESCRIPTION
## Summary
- extend `CircuitComponent` to support an optional `state`
- add play/stop control to palette and disable adding components while simulating
- allow draggable components to react to clicks when in simulation mode
- implement simulation logic and toggle in `App`
- propagate component click handler through `CircuitCanvas`

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68462012ea048327845fcc625adb6b12