### PR TITLE
Implement palette icons and pin label editing

### DIFF
--- a/src/components/ComponentPalette/Palette.tsx
+++ b/src/components/ComponentPalette/Palette.tsx
@@ -1,37 +1,47 @@
 // src/components/ComponentPalette/Palette.tsx
-
 import React from 'react';
 import { ComponentType } from '../../types/circuit';
-import Button from '../UI/Button';
+import PaletteIcon from './PaletteIcon';
 
 interface PaletteProps {
   onAddComponent: (type: ComponentType) => void;
-  onToggleSimulation: () => void; // NEU
-  isSimulating: boolean; // NEU
+  onToggleSimulation: () => void;
+  isSimulating: boolean;
 }
 
+const PaletteButton: React.FC<{ type: ComponentType, onAddComponent: (type: ComponentType) => void, disabled: boolean }> = ({ type, onAddComponent, disabled }) => (
+  <button onClick={() => onAddComponent(type)} disabled={disabled} className="palette-button">
+    <PaletteIcon type={type} />
+    <span className="palette-button-label">{type}</span>
+  </button>
+);
+
 const Palette: React.FC<PaletteProps> = ({ onAddComponent, onToggleSimulation, isSimulating }) => {
+  const componentsToAdd = [
+    ComponentType.PushbuttonNO, ComponentType.PushbuttonNC,
+    ComponentType.NormallyOpen, ComponentType.NormallyClosed,
+    ComponentType.Coil, ComponentType.Lamp, ComponentType.Motor
+  ];
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <div>
         <h3 style={{ marginTop: 0 }}>Bauteile</h3>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-          {/* Die Buttons sind im Simulationsmodus deaktiviert */}
-          <Button label="Schließer hinzufügen" onClick={() => onAddComponent(ComponentType.NormallyOpen)} disabled={isSimulating} />
-          <Button label="Öffner hinzufügen" onClick={() => onAddComponent(ComponentType.NormallyClosed)} disabled={isSimulating} />
-          <Button label="Motor hinzufügen" onClick={() => onAddComponent(ComponentType.Motor)} disabled={isSimulating} />
-          <Button label="Lampe hinzufügen" onClick={() => onAddComponent(ComponentType.Lamp)} disabled={isSimulating} />
+        <div className="palette-grid">
+          {componentsToAdd.map(type => (
+            <PaletteButton key={type} type={type} onAddComponent={onAddComponent} disabled={isSimulating} />
+          ))}
         </div>
       </div>
-
-      {/* NEU: Simulations-Steuerung am unteren Rand der Palette */}
       <div style={{ marginTop: 'auto' }}>
         <h3 style={{ borderTop: '1px solid #ccc', paddingTop: '1rem' }}>Simulation</h3>
-        <Button
-          label={isSimulating ? 'Simulation Stoppen' : 'Simulation Starten'}
+        <button
           onClick={onToggleSimulation}
-          style={{ backgroundColor: isSimulating ? '#f44336' : '#4CAF50', color: 'white', width: '100%' }}
-        />
+          className="simulation-button"
+          style={{ backgroundColor: isSimulating ? '#f44336' : '#4CAF50' }}
+        >
+          {isSimulating ? 'Simulation Stoppen' : 'Simulation Starten'}
+        </button>
       </div>
     </div>
   );

--- a/src/components/ComponentPalette/PaletteIcon.tsx
+++ b/src/components/ComponentPalette/PaletteIcon.tsx
@@ -1,0 +1,34 @@
+// src/components/ComponentPalette/PaletteIcon.tsx
+import React from 'react';
+import { ComponentType } from '../../types/circuit';
+
+interface PaletteIconProps {
+  type: ComponentType;
+}
+
+const PaletteIcon: React.FC<PaletteIconProps> = ({ type }) => {
+  const style: React.CSSProperties = { stroke: 'currentColor', strokeWidth: 2, fill: 'none' };
+  const size = 32;
+
+  const getIcon = () => {
+    switch (type) {
+      case ComponentType.NormallyOpen:
+      case ComponentType.PushbuttonNO:
+        return <g><line x1="16" y1="4" x2="16" y2="12" style={style} /><line x1="16" y1="20" x2="16" y2="28" style={style} /><line x1="12" y1="12" x2="20" y2="20" style={style} /></g>;
+      case ComponentType.NormallyClosed:
+      case ComponentType.PushbuttonNC:
+        return <g><line x1="16" y1="4" x2="16" y2="12" style={style} /><line x1="16" y1="20" x2="16" y2="28" style={style} /><line x1="12" y1="20" x2="20" y2="12" style={style} /></g>;
+      case ComponentType.Coil:
+        return <rect x="8" y="6" width="16" height="20" style={style} />;
+      case ComponentType.Lamp:
+        return <g><circle cx="16" cy="16" r="10" style={style} /><line x1="9" y1="9" x2="23" y2="23" style={style} /><line x1="23" y1="9" x2="9" y2="23" style={style} /></g>;
+      case ComponentType.Motor:
+        return <g><circle cx="16" cy="16" r="12" style={style} /><text x="12" y="21" fontSize="14px" style={{ fill: 'currentColor', stroke: 'none' }}>M</text></g>;
+      default:
+        return null;
+    }
+  };
+  return (<svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>{getIcon()}</svg>);
+};
+
+export default PaletteIcon;

--- a/src/components/ElectricalComponents/DraggableComponent.tsx
+++ b/src/components/ElectricalComponents/DraggableComponent.tsx
@@ -29,49 +29,23 @@ const DraggableComponent: React.FC<DraggableComponentProps> = ({ component, isSe
           </>
         );
 
-      case ComponentType.NormallyOpen: // Schließer
-        // NEU: Zeichnet basierend auf dem Zustand
+      case ComponentType.NormallyOpen:
+      case ComponentType.PushbuttonNO:
         if (component.state?.isOpen === false) {
-          // Geschlossen
-          return (
-            <>
-              <line x1="10" y1="0" x2="10" y2="40" style={style} />
-              <text x="20" y="25" style={textStyle}>{component.label}</text>
-            </>
-          );
+          return <><line x1="10" y1="0" x2="10" y2="40" style={style} /><text x="20" y="25" style={textStyle}>{component.label}</text></>;
         }
-        // Offen (Standard)
-        return (
-          <>
-            <line x1="10" y1="0" x2="10" y2="10" style={style} />
-            <line x1="10" y1="30" x2="10" y2="40" style={style} />
-            <line x1="0" y1="10" x2="10" y2="20" style={style} />
-            <text x="20" y="25" style={textStyle}>{component.label}</text>
-          </>
-        );
+        return <><line x1="10" y1="0" x2="10" y2="10" style={style} /><line x1="10" y1="30" x2="10" y2="40" style={style} /><line x1="0" y1="10" x2="10" y2="20" style={style} /><text x="20" y="25" style={textStyle}>{component.label}</text></>;
 
-      case ComponentType.NormallyClosed: // Öffner
-        // NEU: Zeichnet basierend auf dem Zustand
+      case ComponentType.NormallyClosed:
+      case ComponentType.PushbuttonNC:
+        // KORRIGIERTE GRAFIK FÜR ÖFFNER (mit Nase)
         if (component.state?.isOpen === true) {
-          // Geöffnet
-          return (
-            <>
-              <line x1="10" y1="0" x2="10" y2="10" style={style} />
-              <line x1="10" y1="30" x2="10" y2="40" style={style} />
-              <line x1="0" y1="10" x2="10" y2="20" style={style} />
-              <text x="25" y="25" style={textStyle}>{component.label}</text>
-            </>
-          );
+             return <><line x1="10" y1="0" x2="10" y2="10" style={style} /><line x1="10" y1="30" x2="10" y2="40" style={style} /><line x1="0" y1="10" x2="10" y2="20" style={style} /><text x="25" y="25" style={textStyle}>{component.label}</text></>;
         }
-        // Geschlossen (Standard)
-        return (
-          <>
-            <line x1="10" y1="0" x2="10" y2="15" style={style} />
-            <line x1="10" y1="25" x2="10" y2="40" style={style} />
-            <line x1="10" y1="15" x2="20" y2="25" style={style} />
-            <text x="25" y="25" style={textStyle}>{component.label}</text>
-          </>
-        );
+        return <><line x1="10" y1="0" x2="10" y2="15" style={style} /><line x1="10" y1="25" x2="10" y2="40" style={style} /><line x1="10" y1="15" x2="20" y2="25" style={style} /><text x="25" y="25" style={textStyle}>{component.label}</text></>;
+
+      case ComponentType.Coil:
+        return <><rect x="5" y="5" width="30" height="20" style={style} /><text x="40" y="22" style={textStyle}>{component.label}</text></>;
 
       case ComponentType.Motor:
         return (

--- a/src/components/UI/DetailsSidebar.tsx
+++ b/src/components/UI/DetailsSidebar.tsx
@@ -1,5 +1,4 @@
 // src/components/UI/DetailsSidebar.tsx
-
 import React from 'react';
 import { CircuitComponent } from '../../types/circuit';
 
@@ -8,12 +7,11 @@ interface DetailsSidebarProps {
   onDelete: (componentId: string) => void;
   onClose: () => void;
   onLabelChange: (componentId: string, newLabel: string) => void;
+  onPinLabelChange: (pinId: string, newLabel: string) => void;
 }
 
-const DetailsSidebar: React.FC<DetailsSidebarProps> = ({ selectedComponent, onDelete, onClose, onLabelChange }) => {
-  if (!selectedComponent) {
-    return null;
-  }
+const DetailsSidebar: React.FC<DetailsSidebarProps> = ({ selectedComponent, onDelete, onClose, onLabelChange, onPinLabelChange }) => {
+  if (!selectedComponent) return null;
 
   return (
     <aside className="details-sidebar">
@@ -22,19 +20,26 @@ const DetailsSidebar: React.FC<DetailsSidebarProps> = ({ selectedComponent, onDe
         <button onClick={onClose} className="close-btn">&times;</button>
       </div>
       <div className="sidebar-content">
-        <p><strong>ID:</strong> {selectedComponent.id}</p>
-        <p><strong>Typ:</strong> {selectedComponent.type}</p>
-        <p><strong>Bezeichnung:</strong></p>
-        <input
-          type="text"
-          value={selectedComponent.label}
-          onChange={(e) => onLabelChange(selectedComponent.id, e.target.value)}
-          className="details-input"
-        />
-        <button onClick={() => onDelete(selectedComponent.id)} className="delete-btn">
-          Bauteil löschen
-        </button>
+        <div>
+            <p><strong>Bezeichnung:</strong></p>
+            <input type="text" value={selectedComponent.label} onChange={(e) => onLabelChange(selectedComponent.id, e.target.value)} className="details-input"/>
+        </div>
+
+        {selectedComponent.pins.length > 0 && (
+          <div>
+            <p><strong>Anschlüsse:</strong></p>
+            {selectedComponent.pins.map((pin, index) => (
+              <div key={pin.id} className="pin-edit-row">
+                <label htmlFor={pin.id}>{`Kontakt ${index + 1}`}:</label>
+                <input id={pin.id} type="text" value={pin.label} onChange={(e) => onPinLabelChange(pin.id, e.target.value)} className="details-input pin-input" />
+              </div>
+            ))}
+          </div>
+        )}
       </div>
+      <button onClick={() => onDelete(selectedComponent.id)} className="delete-btn">
+        Bauteil löschen
+      </button>
     </aside>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -96,3 +96,59 @@ body {
 .delete-btn:hover {
   background-color: #d32f2f;
 }
+
+/* NEUE STILE */
+.palette-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+.palette-button {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: white;
+  cursor: pointer;
+  height: 60px;
+  color: #333;
+}
+.palette-button:hover {
+  border-color: #007bff;
+  color: #007bff;
+}
+.palette-button:disabled {
+  color: #ccc;
+  border-color: #eee;
+  cursor: not-allowed;
+}
+.palette-button-label {
+  font-size: 10px;
+  text-align: center;
+}
+.simulation-button {
+  width: 100%;
+  padding: 10px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+}
+.pin-edit-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+.pin-edit-row label {
+    flex-basis: 40%;
+}
+.pin-edit-row .pin-input {
+    flex-basis: 55%;
+    margin: 0;
+}
+

--- a/src/types/circuit.ts
+++ b/src/types/circuit.ts
@@ -1,55 +1,40 @@
 // src/types/circuit.ts
 
-/**
- * Definiert die möglichen Typen für unsere elektrischen Komponenten.
- * Die Verwendung eines Enums macht den Code lesbarer und vermeidet Tippfehler.
- */
 export enum ComponentType {
   PowerSource24V = '24V',
   PowerSource0V = '0V',
-  NormallyOpen = 'Schließer', // Schließer
-  NormallyClosed = 'Öffner', // Öffner
+  NormallyOpen = 'Schalter (Schließer)',
+  NormallyClosed = 'Schalter (Öffner)',
+  PushbuttonNO = 'Taster (Schließer)',
+  PushbuttonNC = 'Taster (Öffner)',
+  Coil = 'Schützspule',
   Motor = 'Motor',
   Lamp = 'Lampe',
 }
 
-/**
- * Repräsentiert einen einzelnen Anschlusspunkt (Pin) einer Komponente.
- */
 export interface Pin {
-  id: string;      // Eindeutige ID des Pins, z.B. 's1-pin-13'
-  componentId: string; // ID der Komponente, zu der der Pin gehört
-  label: string;   // Die Beschriftung des Pins, z.B. '13', 'A1'
-  position: { x: number; y: number }; // RELATIVE Position zum Bauteil-Ursprung
+  id: string;
+  componentId: string;
+  label: string;
+  position: { x: number; y: number };
 }
 
-/**
- * Die Basis-Schnittstelle für jede Komponente auf der Zeichenfläche.
- * Jede Komponente, egal welchen Typs, wird diese Eigenschaften haben.
- */
 export interface CircuitComponent {
-  id: string;                   // Eindeutige ID der Komponente, z.B. 's1'
-  type: ComponentType;          // Der Typ der Komponente (siehe Enum oben)
-  label: string;                // Die vom Benutzer vergebene Bezeichnung, z.B. 'S1'
-  position: { x: number; y: number }; // Die X/Y-Koordinaten auf der Zeichenfläche
-  pins: Pin[];                  // Eine Liste der Anschlusspunkte
-  state?: { [key: string]: any }; // NEU: Optionaler Zustand für das Bauteil
+  id: string;
+  type: ComponentType;
+  label: string;
+  position: { x: number; y: number };
+  pins: Pin[];
+  state?: { [key: string]: any };
 }
 
-/**
- * Repräsentiert eine Verbindung (ein Kabel) zwischen zwei Pins.
- */
 export interface Connection {
-  id: string;      // Eindeutige ID der Verbindung
-  startPinId: string; // Die ID des Start-Pins
-  endPinId: string;   // Die ID des End-Pins
+  id: string;
+  startPinId: string;
+  endPinId: string;
 }
 
-/**
- * Repräsentiert den gesamten Zustand unserer Schaltung.
- * Dies ist das zentrale Datenmodell unserer Anwendung.
- */
 export interface CircuitState {
-  components: { [id: string]: CircuitComponent }; // Alle Komponenten, indiziert nach ihrer ID für schnellen Zugriff
-  connections: { [id: string]: Connection };      // Alle Verbindungen, ebenfalls indiziert nach ID
+  components: { [id: string]: CircuitComponent };
+  connections: { [id: string]: Connection };
 }


### PR DESCRIPTION
## Summary
- add new component types for pushbuttons and coils
- introduce `PaletteIcon` and update component palette UI
- allow editing of pin labels in the details sidebar
- refine draggable component drawings
- improve connection handling and open sidebar when adding components
- style updates for palette buttons and pin editing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684623cbeaa88327bc0206ee8ef27767